### PR TITLE
Fixed and small readability refactoring. Seems like pokevision change…

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -33,8 +33,6 @@ namespace PoGo.NecroBot.Logic.Tasks
         public double expiration_time { get; set; }
         public double latitude { get; set; }
         public double longitude { get; set; }
-        public string uid { get; set; }
-        public bool is_alive { get; set; }
         public int pokemonId { get; set; }
 
         public PokemonLocation(double _latitude, double _longitude)
@@ -249,11 +247,15 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                         var scanResult = SnipeScanForPokemon(location);
 
-                        var locationsToSnipe = scanResult.pokemon == null ? new List<PokemonLocation>() : scanResult.pokemon.Where(q =>
-                            pokemonIds.Contains((PokemonId)q.pokemonId)
-                            && !locsVisited.Contains(q)
-                            && q.expiration_time < currentTimestamp
-                            && q.is_alive).ToList();
+                        var locationsToSnipe = new List<PokemonLocation>();
+                        if (scanResult.pokemon != null)
+                        {
+                            var filteredPokemon = scanResult.pokemon.Where(q => pokemonIds.Contains((PokemonId)q.pokemonId));
+                            var notVisitedPokemon = filteredPokemon.Where(q => !locsVisited.Contains(q));
+                            var notExpiredPokemon = notVisitedPokemon.Where(q => q.expiration_time < currentTimestamp);
+
+                            locationsToSnipe.AddRange(notExpiredPokemon);
+                        }
 
                         if (locationsToSnipe.Any())
                         {


### PR DESCRIPTION
…d the json and removed the is_alive entry.

"{"
status":"success",
"pokemon":[
{"id":719183341,
"latitude":37.807812375435,
"longitude":-122.42128665472,
"pokemonId":16,
"expiration_time":1469827668
},