### PR TITLE
Enhanced Renaming

### DIFF
--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -83,7 +83,8 @@ namespace PoGo.NecroBot.Logic
         bool EvolveAllPokemonAboveIv { get; }
         float EvolveAboveIvValue { get; }
         bool DumpPokemonStats { get; }
-        bool RenameAboveIv { get; }
+        bool RenamePokemon { get; }
+        bool RenameOnlyAboveIv { get; }
         string RenameTemplate { get; }
         int AmountOfPokemonToDisplayOnStart { get; }
         string TranslationLanguageCode { get; }

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -124,7 +124,8 @@ namespace PoGo.NecroBot.CLI
         public float KeepMinIvPercentage = 95;
         public bool KeepPokemonsThatCanEvolve = false;
         public bool PrioritizeIvOverCp = true;
-        public bool RenameAboveIv = true;
+        public bool RenamePokemon = false;
+        public bool RenameOnlyAboveIv = true;
         public string RenameTemplate = "{1}_{0}";
         public bool TransferDuplicatePokemon = true;
         public string TranslationLanguageCode = "en";
@@ -582,7 +583,8 @@ namespace PoGo.NecroBot.CLI
         public int UseLuckyEggsMinPokemonAmount => _settings.UseLuckyEggsMinPokemonAmount;
         public bool EvolveAllPokemonAboveIv => _settings.EvolveAllPokemonAboveIv;
         public float EvolveAboveIvValue => _settings.EvolveAboveIvValue;
-        public bool RenameAboveIv => _settings.RenameAboveIv;
+        public bool RenamePokemon => _settings.RenamePokemon;
+        public bool RenameOnlyAboveIv => _settings.RenameOnlyAboveIv;
         public string RenameTemplate => _settings.RenameTemplate;
         public int AmountOfPokemonToDisplayOnStart => _settings.AmountOfPokemonToDisplayOnStart;
         public bool DumpPokemonStats => _settings.DumpPokemonStats;

--- a/PoGo.NecroBot.Logic/State/FarmState.cs
+++ b/PoGo.NecroBot.Logic/State/FarmState.cs
@@ -22,7 +22,7 @@ namespace PoGo.NecroBot.Logic.State
                 await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
             }
 
-            if (session.LogicSettings.RenameAboveIv)
+            if (session.LogicSettings.RenamePokemon)
             {
                 await RenamePokemonTask.Execute(session, cancellationToken);
             }

--- a/PoGo.NecroBot.Logic/Tasks/Farm.cs
+++ b/PoGo.NecroBot.Logic/Tasks/Farm.cs
@@ -30,7 +30,7 @@ namespace PoGo.NecroBot.Logic.Service
                 TransferDuplicatePokemonTask.Execute(_session, cancellationToken).Wait();
             }
 
-            if (_session.LogicSettings.RenameAboveIv)
+            if (_session.LogicSettings.RenamePokemon)
             {
                 RenamePokemonTask.Execute(_session, cancellationToken).Wait();
             }

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
@@ -126,7 +126,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                                 await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
                             }
 
-                            if (session.LogicSettings.RenameAboveIv)
+                            if (session.LogicSettings.RenamePokemon)
                             {
                                 await RenamePokemonTask.Execute(session, cancellationToken);
                             }

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
@@ -168,7 +168,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                     {
                         await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
                     }
-                    if (session.LogicSettings.RenameAboveIv)
+                    if (session.LogicSettings.RenamePokemon)
                     {
                         await RenamePokemonTask.Execute(session, cancellationToken);
                     }

--- a/PoGo.NecroBot.Logic/Tasks/RenamePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/RenamePokemonTask.cs
@@ -36,8 +36,9 @@ namespace PoGo.NecroBot.Logic.Tasks
                 string newNickname = String.Format(session.LogicSettings.RenameTemplate, pokemonName, perfection);
                 string oldNickname = (pokemon.Nickname.Length != 0) ? pokemon.Nickname : pokemon.PokemonId.ToString();
 
-                if (perfection >= session.LogicSettings.KeepMinIvPercentage && newNickname != oldNickname &&
-                    session.LogicSettings.RenameAboveIv)
+                // If "RenameOnlyAboveIv" = true only rename pokemon with IV over "KeepMinIvPercentage"
+                // Favorites will be skipped
+                if ((!session.LogicSettings.RenameOnlyAboveIv || perfection >= session.LogicSettings.KeepMinIvPercentage) && newNickname != oldNickname && pokemon.Favorite == 0)
                 {
                     await session.Client.Inventory.NicknamePokemon(pokemon.Id, newNickname);
 


### PR DESCRIPTION
1. The bot won't rename favorites.
2. Instead of "RenameAboveIv" you now have
"RenamePokemon" which renames all pokemon not transfered and
"RenameOnlyAboveIv" which skips pokemon with less than
KeepMinIvPercentage IV.

With both true you have the old behavior.
"RenameOnlyAboveIv" alone will do nothing.

I think it's easier to maintain and extend than #1416
https://github.com/NecronomiconCoding/NecroBot/pull/1416